### PR TITLE
feat: add PostgreSQL service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,19 @@ services:
       - "80:80"
     depends_on:
       - backend
+
+  db:
+    image: postgres:17
+    restart: always
+    environment:
+      - POSTGRES_DB=notakeoutdb
+      - POSTGRES_USER=notakeoutdb
+      - POSTGRES_PASSWORD=notakeout2026
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  db_data:
+    driver: local


### PR DESCRIPTION
Add PostgreSQL container to the local development environment using Docker Compose.

- Use official postgres:17 image
- Configure database credentials via environment variables
- Expose port 5432
- Add named volume for data persistence