### PR TITLE
feat: connect Flask application to PostgreSQL using SQLAlchemy

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,7 +7,7 @@ FLASK_RUN_HOST=0.0.0.0
 FLASK_ENV=development
 
 # Banco de dados
-DATABASE_URL=sqlite:///notakeout.db
+DATABASE_URL=postgresql://notakeoutdb:notakeout2026@db:5432/notakeoutdb
 
 # Outras variáveis de ambiente
 SECRET_KEY=troque-por-uma-chave-secreta

--- a/backend/app.py
+++ b/backend/app.py
@@ -10,7 +10,7 @@ from routes.menu_routes import menu_bp
 
 app = Flask(__name__)
 CORS(app)
-database_url = os.getenv("DATABASE_URL", "sqlite:///notakeout.db")
+database_url = os.getenv("DATABASE_URL")
 app.config["SQLALCHEMY_DATABASE_URI"] = database_url
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db.init_app(app)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ mistune==3.1.3
 packaging==24.2
 pillow==11.1.0
 pyyaml==6.0.2
+psycopg2-binary
 referencing==0.36.2
 reportlab==4.3.1
 rpds-py==0.24.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,12 @@ services:
       - FLASK_APP=app.py
       - FLASK_RUN_HOST=0.0.0.0
       - FLASK_ENV=development
+    env_file:
+      - ./backend/.env
     volumes:
       - ./backend:/app
+    depends_on:
+      - db
 
   frontend:
     build:


### PR DESCRIPTION
Implements the connection between the Flask backend and PostgreSQL using SQLAlchemy.

Changes:
- configured DATABASE_URL for PostgreSQL
- removed SQLite fallback in Docker environment
- added psycopg driver
- configured backend container to receive DATABASE_URL
- ensured backend starts after database service
- validated table creation and CRUD operations in PostgreSQL

Acceptance criteria validated:
- backend connects to PostgreSQL
- SQLAlchemy creates tables
- CRUD operations persist data in PostgreSQL